### PR TITLE
Correct usage of retain header in example message

### DIFF
--- a/apollo-website/src/documentation/user-manual.md
+++ b/apollo-website/src/documentation/user-manual.md
@@ -1267,7 +1267,7 @@ that looks like:
 
     SEND
     destination:/topic/stock/IBM
-    retain:true
+    retain:set
 
     112.12
     ^@


### PR DESCRIPTION
Example code for sending topic retained messages uses incorrect semantics "retain:true" instead of "retain:set" as is correctly documented in the surrounding text.
