### PR TITLE
APLO-392 Fix SASL methods ordering

### DIFF
--- a/apollo-amqp/src/main/scala/org/apache/activemq/apollo/amqp/AmqpProtocolHandler.scala
+++ b/apollo-amqp/src/main/scala/org/apache/activemq/apollo/amqp/AmqpProtocolHandler.scala
@@ -266,7 +266,7 @@ class AmqpProtocolHandler extends ProtocolHandler {
 
     override def processSaslConnect(protonTransport: TransportImpl) = {
       val sasl = protonTransport.sasl();
-      sasl.setMechanisms(Array("ANONYMOUS", "PLAIN"));
+      sasl.setMechanisms(Array("PLAIN", "ANONYMOUS"));
       sasl.server();
       sasl
     }


### PR DESCRIPTION
Preferred method (PLAIN) should go first
